### PR TITLE
fix: forward error instead of generating an 'Fatal error' on KeychainError.couldNotAccessKeychain

### DIFF
--- a/Raivo MacOS/Helpers/CryptographyHelper.swift
+++ b/Raivo MacOS/Helpers/CryptographyHelper.swift
@@ -37,7 +37,7 @@ class CryptographyHelper {
             throw CryptographyError.decryptionFailed("Cipher was not a valid base64 string")
         }
         
-        let proposedPassword = try! key ?? StorageHelper.shared.getDecryptionPassword()
+        let proposedPassword = try key ?? StorageHelper.shared.getDecryptionPassword()
         
         guard let password = proposedPassword else {
             throw CryptographyError.decryptionFailed("Encryption password unknown (not available in the keychain or as parameter)")


### PR DESCRIPTION
This PR changes the error handling in `decrypt` to forward the error instead of generating an 'Fatal error' on KeychainError.couldNotAccessKeychain.

In certain conditions I noticed that my raivo macos app stopped working/was terminated.

Crash reports revealed:
> Raivo_OTP/CryptographyHelper.swift:40: Fatal error: 'try!' expression unexpectedly raised an error: KeychainError.couldNotAccessKeychain

From looking at the time of the crash report, this seems to be very likely related to situations where the system was in sleep mode and the keychain was locked at that point of time.


